### PR TITLE
[FIX] removing unnecessary dependency

### DIFF
--- a/jekyll-i18n.gemspec
+++ b/jekyll-i18n.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 	s.homepage    = 'http://rubygems.org/gems/jekyll-i18n'
 	s.license     = 'GPL-3'
 	
-	s.add_runtime_dependency 'jekyll', '~> 1.3.1'
+	s.add_runtime_dependency 'jekyll'
 	gem "i18n", "~> 0.6.4"
 	
 	s.files       = ["lib/jekyll-i18n.rb", 'README.md', 'LICENSE']


### PR DESCRIPTION
This explicit dependency was not allowing me to use the gem with Jekyll 1.5.1.
